### PR TITLE
Update SmofUpdateQuery.java

### DIFF
--- a/src/org/smof/collection/SmofUpdateQuery.java
+++ b/src/org/smof/collection/SmofUpdateQuery.java
@@ -35,7 +35,7 @@ import org.smof.parsers.SmofParser;
 @SuppressWarnings("javadoc")
 public class SmofUpdateQuery<T extends Element> {
 
-	private static void handleError(Throwable cause) {
+	private void handleError(Throwable cause) {
 		throw new SmofException(cause);
 	}
 	


### PR DESCRIPTION
Removed static from handleError, its is unnecessary, because the access for this method is local inside the objects.